### PR TITLE
Add variable inference resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ python consistory_CLI.py --subject "a cute dog" --concept_token "dog" --settings
 - **`--settings`**: A list of settings or backgrounds for generating different scenarios, e.g., `"sitting in the beach"` or `"in the circus"`.
 - **`--cache_cpu_offloading`**: Boolean to indicate whether to offload the anchors cache to the CPU. This reduces memory usage but may slow down generation.
 - **`--out_dir`**: The output directory where generated images will be saved.
+- **`--height`** / **`--width`**: Desired output resolution in pixels. Defaults to `1024`.
 
 #### Example commands
 1. **Batch generation:**

--- a/consistory_CLI.py
+++ b/consistory_CLI.py
@@ -7,15 +7,33 @@ import os
 import argparse
 from consistory_run import load_pipeline, run_batch_generation, run_anchor_generation, run_extra_generation
 
-def run_batch(gpu, seed=40, mask_dropout=0.5, same_latent=False,
-              style="A photo of ", subject="a cute dog", concept_token=['dog'],
-              settings=["sitting in the beach", "standing in the snow"],
-              out_dir = None):
+def run_batch(
+    gpu,
+    seed=40,
+    mask_dropout=0.5,
+    same_latent=False,
+    style="A photo of ",
+    subject="a cute dog",
+    concept_token=["dog"],
+    settings=["sitting in the beach", "standing in the snow"],
+    out_dir=None,
+    height=1024,
+    width=1024,
+):
     
     story_pipeline = load_pipeline(gpu)
     prompts = [f'{style}{subject} {setting}' for setting in settings]
 
-    images, image_all = run_batch_generation(story_pipeline, prompts, concept_token, seed, mask_dropout=mask_dropout, same_latent=same_latent)
+    images, image_all = run_batch_generation(
+        story_pipeline,
+        prompts,
+        concept_token,
+        seed,
+        mask_dropout=mask_dropout,
+        same_latent=same_latent,
+        height=height,
+        width=width,
+    )
 
     if out_dir is not None:
         for i, image in enumerate(images):
@@ -23,27 +41,56 @@ def run_batch(gpu, seed=40, mask_dropout=0.5, same_latent=False,
 
     return images, image_all
 
-def run_cached_anchors(gpu, seed=40, mask_dropout=0.5, same_latent=False,
-                style="A photo of ", subject="a cute dog", concept_token=['dog'],
-                settings=["sitting in the beach", "standing in the snow"],
-                cache_cpu_offloading=False, out_dir = None):
+def run_cached_anchors(
+    gpu,
+    seed=40,
+    mask_dropout=0.5,
+    same_latent=False,
+    style="A photo of ",
+    subject="a cute dog",
+    concept_token=["dog"],
+    settings=["sitting in the beach", "standing in the snow"],
+    cache_cpu_offloading=False,
+    out_dir=None,
+    height=1024,
+    width=1024,
+):
     
     story_pipeline = load_pipeline(gpu)
     prompts = [f'{style}{subject} {setting}' for setting in settings]
     anchor_prompts = prompts[:2]
     extra_prompts = prompts[2:]
 
-    anchor_out_images, anchor_image_all, anchor_cache_first_stage, anchor_cache_second_stage = run_anchor_generation(story_pipeline, anchor_prompts, concept_token, 
-                                                                                                        seed=seed, mask_dropout=mask_dropout, same_latent=same_latent,
-                                                                                                        cache_cpu_offloading=cache_cpu_offloading)
+    anchor_out_images, anchor_image_all, anchor_cache_first_stage, anchor_cache_second_stage = run_anchor_generation(
+        story_pipeline,
+        anchor_prompts,
+        concept_token,
+        seed=seed,
+        mask_dropout=mask_dropout,
+        same_latent=same_latent,
+        cache_cpu_offloading=cache_cpu_offloading,
+        height=height,
+        width=width,
+    )
     
     if out_dir is not None:
         for i, image in enumerate(anchor_out_images):
             image.save(f'{out_dir}/anchor_image_{i}.png')
 
     for i, extra_prompt in enumerate(extra_prompts):
-        extra_out_images, extra_image_all = run_extra_generation(story_pipeline, [extra_prompt], concept_token, anchor_cache_first_stage, anchor_cache_second_stage, 
-                                                    seed=seed, mask_dropout=mask_dropout, same_latent=same_latent, cache_cpu_offloading=cache_cpu_offloading)
+        extra_out_images, extra_image_all = run_extra_generation(
+            story_pipeline,
+            [extra_prompt],
+            concept_token,
+            anchor_cache_first_stage,
+            anchor_cache_second_stage,
+            seed=seed,
+            mask_dropout=mask_dropout,
+            same_latent=same_latent,
+            cache_cpu_offloading=cache_cpu_offloading,
+            height=height,
+            width=width,
+        )
         
         if out_dir is not None:
             extra_out_images[0].save(f'{out_dir}/extra_image_{i}.png')
@@ -64,6 +111,9 @@ if __name__ == '__main__':
     parser.add_argument('--settings', default=["sitting in the beach", "standing in the snow"], 
                         type=str, nargs='*', required=False)
     parser.add_argument('--cache_cpu_offloading', default=False, type=bool, required=False)
+
+    parser.add_argument('--height', default=1024, type=int, required=False)
+    parser.add_argument('--width', default=1024, type=int, required=False)
     
     parser.add_argument('--out_dir', default=None, type=str, required=False)
 
@@ -73,10 +123,33 @@ if __name__ == '__main__':
         os.makedirs(args.out_dir, exist_ok=True)
 
     if args.run_type == "batch":
-        run_batch(args.gpu, args.seed, args.mask_dropout, args.same_latent, args.style, 
-                  args.subject, args.concept_token, args.settings, args.out_dir)
+        run_batch(
+            args.gpu,
+            args.seed,
+            args.mask_dropout,
+            args.same_latent,
+            args.style,
+            args.subject,
+            args.concept_token,
+            args.settings,
+            args.out_dir,
+            args.height,
+            args.width,
+        )
     elif args.run_type == "cached":
-        run_cached_anchors(args.gpu, args.seed, args.mask_dropout, args.same_latent, args.style, 
-                           args.subject, args.concept_token, args.settings, args.cache_cpu_offloading, args.out_dir)
+        run_cached_anchors(
+            args.gpu,
+            args.seed,
+            args.mask_dropout,
+            args.same_latent,
+            args.style,
+            args.subject,
+            args.concept_token,
+            args.settings,
+            args.cache_cpu_offloading,
+            args.out_dir,
+            args.height,
+            args.width,
+        )
     else:
         print("Invalid run type")

--- a/consistory_cache.py
+++ b/consistory_cache.py
@@ -50,14 +50,24 @@ def create_token_indices(prompts, batch_size, concept_token, tokenizer):
 
     return token_indices
 
-def create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type):
+def create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type, height, width):
     # if seed is int
     if isinstance(seed, int):
         g = torch.Generator('cuda').manual_seed(seed)
-        shape = (batch_size, story_pipeline.unet.config.in_channels, 128, 128)
+        shape = (
+            batch_size,
+            story_pipeline.unet.config.in_channels,
+            height // 8,
+            width // 8,
+        )
         latents = randn_tensor(shape, generator=g, device=device, dtype=float_type)
     elif isinstance(seed, list):
-        shape = (batch_size, story_pipeline.unet.config.in_channels, 128, 128)
+        shape = (
+            batch_size,
+            story_pipeline.unet.config.in_channels,
+            height // 8,
+            width // 8,
+        )
         latents = torch.empty(shape, device=device, dtype=float_type)
         for i, seed_i in enumerate(seed):
             g = torch.Generator('cuda').manual_seed(seed_i)
@@ -69,12 +79,22 @@ def create_latents(story_pipeline, seed, batch_size, same_latent, device, float_
 
     return latents, g
 
-def run_anchor_generation(story_pipeline, prompts, concept_token,
-                   seed=40, n_steps=50, mask_dropout=0.5,
-                   same_latent=False, share_queries=True,
-                   perform_sdsa=True, perform_injection=True,
-                   downscale_rate=4):
-    latent_resolutions = [32, 64]
+def run_anchor_generation(
+    story_pipeline,
+    prompts,
+    concept_token,
+    seed=40,
+    n_steps=50,
+    mask_dropout=0.5,
+    same_latent=False,
+    share_queries=True,
+    perform_sdsa=True,
+    perform_injection=True,
+    downscale_rate=4,
+    height=1024,
+    width=1024,
+):
+    latent_resolutions = [min(height, width) // 32, min(height, width) // 16]
 
     device = story_pipeline.device
     tokenizer = story_pipeline.tokenizer
@@ -87,13 +107,24 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
 
     default_attention_store_kwargs = {
         'token_indices': token_indices,
-        'mask_dropout': mask_dropout
+        'mask_dropout': mask_dropout,
+        'attn_res': (height // 32, width // 32),
+        'latent_resolutions': latent_resolutions,
     }
 
     default_extended_attn_kwargs = {'extend_kv_unet_parts': ['up']}
     query_store_kwargs={'t_range': [0,n_steps//10], 'strength_start': 0.9, 'strength_end': 0.81836735}
 
-    latents, g = create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type)
+    latents, g = create_latents(
+        story_pipeline,
+        seed,
+        batch_size,
+        same_latent,
+        device,
+        float_type,
+        height,
+        width,
+    )
 
     anchor_cache_first_stage = AnchorCache()
     anchor_cache_second_stage = AnchorCache()
@@ -155,13 +186,24 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
     
     return out.images, img_all, anchor_cache_first_stage, anchor_cache_second_stage
 
-def run_extra_generation(story_pipeline, prompts, concept_token, 
-                         anchor_cache_first_stage, anchor_cache_second_stage,
-                         seed=40, n_steps=50, mask_dropout=0.5,
-                         same_latent=False, share_queries=True,
-                         perform_sdsa=True, perform_injection=True,
-                         downscale_rate=4):
-    latent_resolutions = [32, 64]
+def run_extra_generation(
+    story_pipeline,
+    prompts,
+    concept_token,
+    anchor_cache_first_stage,
+    anchor_cache_second_stage,
+    seed=40,
+    n_steps=50,
+    mask_dropout=0.5,
+    same_latent=False,
+    share_queries=True,
+    perform_sdsa=True,
+    perform_injection=True,
+    downscale_rate=4,
+    height=1024,
+    width=1024,
+):
+    latent_resolutions = [min(height, width) // 32, min(height, width) // 16]
 
     device = story_pipeline.device
     tokenizer = story_pipeline.tokenizer
@@ -174,7 +216,9 @@ def run_extra_generation(story_pipeline, prompts, concept_token,
 
     default_attention_store_kwargs = {
         'token_indices': token_indices,
-        'mask_dropout': mask_dropout
+        'mask_dropout': mask_dropout,
+        'attn_res': (height // 32, width // 32),
+        'latent_resolutions': latent_resolutions,
     }
 
     default_extended_attn_kwargs = {'extend_kv_unet_parts': ['up']}
@@ -184,7 +228,16 @@ def run_extra_generation(story_pipeline, prompts, concept_token,
     if isinstance(seed, list):
         seed = [seed[0], seed[0], *seed]
 
-    latents, g = create_latents(story_pipeline, seed, extra_batch_size, same_latent, device, float_type)
+    latents, g = create_latents(
+        story_pipeline,
+        seed,
+        extra_batch_size,
+        same_latent,
+        device,
+        float_type,
+        height,
+        width,
+    )
     latents = latents[2:]
 
     anchor_cache_first_stage.set_mode_inject()

--- a/consistory_run.py
+++ b/consistory_run.py
@@ -13,7 +13,11 @@ import gc
 
 from utils.ptp_utils import view_images
 
-LATENT_RESOLUTIONS = [32, 64]
+def get_latent_resolutions(height: int, width: int):
+    latent_h = height // 8
+    latent_w = width // 8
+    min_latent = min(latent_h, latent_w)
+    return [min_latent // 4, min_latent // 2]
 
 def load_pipeline(gpu_id=0):
     float_type = torch.float16
@@ -51,14 +55,24 @@ def create_token_indices(prompts, batch_size, concept_token, tokenizer):
 
     return token_indices
 
-def create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type):
+def create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type, height, width):
     # if seed is int
     if isinstance(seed, int):
         g = torch.Generator('cuda').manual_seed(seed)
-        shape = (batch_size, story_pipeline.unet.config.in_channels, 128, 128)
+        shape = (
+            batch_size,
+            story_pipeline.unet.config.in_channels,
+            height // 8,
+            width // 8,
+        )
         latents = randn_tensor(shape, generator=g, device=device, dtype=float_type)
     elif isinstance(seed, list):
-        shape = (batch_size, story_pipeline.unet.config.in_channels, 128, 128)
+        shape = (
+            batch_size,
+            story_pipeline.unet.config.in_channels,
+            height // 8,
+            width // 8,
+        )
         latents = torch.empty(shape, device=device, dtype=float_type)
         for i, seed_i in enumerate(seed):
             g = torch.Generator('cuda').manual_seed(seed_i)
@@ -71,11 +85,22 @@ def create_latents(story_pipeline, seed, batch_size, same_latent, device, float_
     return latents, g
 
 # Batch inference
-def run_batch_generation(story_pipeline, prompts, concept_token,
-                        seed=40, n_steps=50, mask_dropout=0.5,
-                        same_latent=False, share_queries=True,
-                        perform_sdsa=True, perform_injection=True,
-                        downscale_rate=4, n_achors=2):
+def run_batch_generation(
+    story_pipeline,
+    prompts,
+    concept_token,
+    seed=40,
+    n_steps=50,
+    mask_dropout=0.5,
+    same_latent=False,
+    share_queries=True,
+    perform_sdsa=True,
+    perform_injection=True,
+    downscale_rate=4,
+    n_achors=2,
+    height=1024,
+    width=1024,
+):
     device = story_pipeline.device
     tokenizer = story_pipeline.tokenizer
     float_type = story_pipeline.dtype
@@ -86,16 +111,29 @@ def run_batch_generation(story_pipeline, prompts, concept_token,
     token_indices = create_token_indices(prompts, batch_size, concept_token, tokenizer)
     anchor_mappings = create_anchor_mapping(batch_size, anchor_indices=list(range(n_achors)))
 
+    latent_resolutions = get_latent_resolutions(height, width)
+
     default_attention_store_kwargs = {
         'token_indices': token_indices,
         'mask_dropout': mask_dropout,
-        'extended_mapping': anchor_mappings
+        'extended_mapping': anchor_mappings,
+        'attn_res': (height // 32, width // 32),
+        'latent_resolutions': latent_resolutions,
     }
 
     default_extended_attn_kwargs = {'extend_kv_unet_parts': ['up']}
     query_store_kwargs= {'t_range': [0,n_steps//10], 'strength_start': 0.9, 'strength_end': 0.81836735}
 
-    latents, g = create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type)
+    latents, g = create_latents(
+        story_pipeline,
+        seed,
+        batch_size,
+        same_latent,
+        device,
+        float_type,
+        height,
+        width,
+    )
 
     # ------------------ #
     # Extended attention First Run #
@@ -117,7 +155,12 @@ def run_batch_generation(story_pipeline, prompts, concept_token,
     dift_features = unet.latent_store.dift_features['261_0'][batch_size:]
     dift_features = torch.stack([gaussian_smooth(x, kernel_size=3, sigma=1) for x in dift_features], dim=0)
 
-    nn_map, nn_distances = cyclic_nn_map(dift_features, last_masks, LATENT_RESOLUTIONS, device)
+    nn_map, nn_distances = cyclic_nn_map(
+        dift_features,
+        last_masks,
+        latent_resolutions,
+        device,
+    )
 
     torch.cuda.empty_cache()
     gc.collect()
@@ -147,11 +190,22 @@ def run_batch_generation(story_pipeline, prompts, concept_token,
     return out.images, img_all
 
 # Anchors
-def run_anchor_generation(story_pipeline, prompts, concept_token,
-                        seed=40, n_steps=50, mask_dropout=0.5,
-                        same_latent=False, share_queries=True,
-                        perform_sdsa=True, perform_injection=True,
-                        downscale_rate=4, cache_cpu_offloading=False):
+def run_anchor_generation(
+    story_pipeline,
+    prompts,
+    concept_token,
+    seed=40,
+    n_steps=50,
+    mask_dropout=0.5,
+    same_latent=False,
+    share_queries=True,
+    perform_sdsa=True,
+    perform_injection=True,
+    downscale_rate=4,
+    cache_cpu_offloading=False,
+    height=1024,
+    width=1024,
+):
     device = story_pipeline.device
     tokenizer = story_pipeline.tokenizer
     float_type = story_pipeline.dtype
@@ -161,15 +215,28 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
 
     token_indices = create_token_indices(prompts, batch_size, concept_token, tokenizer)
 
+    latent_resolutions = get_latent_resolutions(height, width)
+
     default_attention_store_kwargs = {
         'token_indices': token_indices,
-        'mask_dropout': mask_dropout
+        'mask_dropout': mask_dropout,
+        'attn_res': (height // 32, width // 32),
+        'latent_resolutions': latent_resolutions,
     }
 
     default_extended_attn_kwargs = {'extend_kv_unet_parts': ['up']}
     query_store_kwargs={'t_range': [0,n_steps//10], 'strength_start': 0.9, 'strength_end': 0.81836735}
 
-    latents, g = create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type)
+    latents, g = create_latents(
+        story_pipeline,
+        seed,
+        batch_size,
+        same_latent,
+        device,
+        float_type,
+        height,
+        width,
+    )
 
     anchor_cache_first_stage = AnchorCache()
     anchor_cache_second_stage = AnchorCache()
@@ -201,7 +268,12 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
     if cache_cpu_offloading:
         anchor_cache_first_stage.to_device(torch.device('cpu'))
 
-    nn_map, nn_distances = cyclic_nn_map(dift_features, last_masks, LATENT_RESOLUTIONS, device)
+    nn_map, nn_distances = cyclic_nn_map(
+        dift_features,
+        last_masks,
+        latent_resolutions,
+        device,
+    )
 
     torch.cuda.empty_cache()
     gc.collect()
@@ -237,12 +309,24 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
     
     return out.images, img_all, anchor_cache_first_stage, anchor_cache_second_stage
 
-def run_extra_generation(story_pipeline, prompts, concept_token, 
-                         anchor_cache_first_stage, anchor_cache_second_stage,
-                         seed=40, n_steps=50, mask_dropout=0.5,
-                         same_latent=False, share_queries=True,
-                         perform_sdsa=True, perform_injection=True,
-                         downscale_rate=4, cache_cpu_offloading=False):
+def run_extra_generation(
+    story_pipeline,
+    prompts,
+    concept_token,
+    anchor_cache_first_stage,
+    anchor_cache_second_stage,
+    seed=40,
+    n_steps=50,
+    mask_dropout=0.5,
+    same_latent=False,
+    share_queries=True,
+    perform_sdsa=True,
+    perform_injection=True,
+    downscale_rate=4,
+    cache_cpu_offloading=False,
+    height=1024,
+    width=1024,
+):
     device = story_pipeline.device
     tokenizer = story_pipeline.tokenizer
     float_type = story_pipeline.dtype
@@ -252,9 +336,13 @@ def run_extra_generation(story_pipeline, prompts, concept_token,
 
     token_indices = create_token_indices(prompts, batch_size, concept_token, tokenizer)
 
+    latent_resolutions = get_latent_resolutions(height, width)
+
     default_attention_store_kwargs = {
         'token_indices': token_indices,
-        'mask_dropout': mask_dropout
+        'mask_dropout': mask_dropout,
+        'attn_res': (height // 32, width // 32),
+        'latent_resolutions': latent_resolutions,
     }
 
     default_extended_attn_kwargs = {'extend_kv_unet_parts': ['up']}
@@ -264,7 +352,16 @@ def run_extra_generation(story_pipeline, prompts, concept_token,
     if isinstance(seed, list):
         seed = [seed[0], seed[0], *seed]
 
-    latents, g = create_latents(story_pipeline, seed, extra_batch_size, same_latent, device, float_type)
+    latents, g = create_latents(
+        story_pipeline,
+        seed,
+        extra_batch_size,
+        same_latent,
+        device,
+        float_type,
+        height,
+        width,
+    )
     latents = latents[2:]
 
     anchor_cache_first_stage.set_mode_inject()
@@ -297,7 +394,14 @@ def run_extra_generation(story_pipeline, prompts, concept_token,
     anchor_dift_features = anchor_cache_first_stage.dift_cache
     anchor_last_masks = anchor_cache_first_stage.anchors_last_mask
 
-    nn_map, nn_distances = anchor_nn_map(dift_features, anchor_dift_features, last_masks, anchor_last_masks, LATENT_RESOLUTIONS, device)
+    nn_map, nn_distances = anchor_nn_map(
+        dift_features,
+        anchor_dift_features,
+        last_masks,
+        anchor_last_masks,
+        latent_resolutions,
+        device,
+    )
 
     if cache_cpu_offloading:
         anchor_cache_first_stage.to_device(torch.device('cpu'))

--- a/utils/ptp_utils.py
+++ b/utils/ptp_utils.py
@@ -106,7 +106,7 @@ class AttentionStore:
         Initialize an empty AttentionStore :param step_index: used to visualize only a specific step in the diffusion
         process
         """
-        self.attn_res = attention_store_kwargs.get('attn_res', (32,32))
+        self.attn_res = attention_store_kwargs.get("attn_res", (32, 32))
         self.token_indices = attention_store_kwargs['token_indices']
         bsz = self.token_indices.size(1)
         self.mask_background_query = attention_store_kwargs.get('mask_background_query', False)
@@ -116,7 +116,7 @@ class AttentionStore:
         torch.manual_seed(0) # For dropout mask reproducibility
 
         self.curr_iter = 0
-        self.ALL_RES = [32, 64]
+        self.ALL_RES = attention_store_kwargs.get("latent_resolutions", [32, 64])
         self.step_store = defaultdict(list)
         self.attn_masks = {res: None for res in self.ALL_RES}
         self.last_mask = {res: None for res in self.ALL_RES}


### PR DESCRIPTION
## Summary
- add `height`/`width` options to command line interface
- compute latent resolutions dynamically in runtime scripts
- support variable image size in anchor helper functions
- expand AttentionStore to accept dynamic latent resolutions
- document new resolution parameters

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6887279d53508331a1f018d3b27de69c