### PR TITLE
Enable dynamic image resolution

### DIFF
--- a/attention_processor.py
+++ b/attention_processor.py
@@ -258,19 +258,22 @@ class ConsistoryExtendedAttnXFormersAttnProcessor:
 
 
 def register_extended_self_attn(unet, attnstore, extended_attn_kwargs):
-    DICT_PLACE_TO_RES = {'down_0': 64, 'down_1': 64, 'down_2': 64, 'down_3': 64, 'down_4': 64, 'down_5': 64, 'down_6': 64, 'down_7': 64,
-                         'down_8': 32, 'down_9': 32, 'down_10': 32, 'down_11': 32, 'down_12': 32, 'down_13': 32, 'down_14': 32, 'down_15': 32,
-                         'down_16': 32, 'down_17': 32, 'down_18': 32, 'down_19': 32, 'down_20': 32, 'down_21': 32, 'down_22': 32, 'down_23': 32,
-                         'down_24': 32, 'down_25': 32, 'down_26': 32, 'down_27': 32, 'down_28': 32, 'down_29': 32, 'down_30': 32, 'down_31': 32,
-                         'down_32': 32, 'down_33': 32, 'down_34': 32, 'down_35': 32, 'down_36': 32, 'down_37': 32, 'down_38': 32, 'down_39': 32,
-                         'down_40': 32, 'down_41': 32, 'down_42': 32, 'down_43': 32, 'down_44': 32, 'down_45': 32, 'down_46': 32, 'down_47': 32,
-                         'mid_120': 32, 'mid_121': 32, 'mid_122': 32, 'mid_123': 32, 'mid_124': 32, 'mid_125': 32, 'mid_126': 32, 'mid_127': 32,
-                         'mid_128': 32, 'mid_129': 32, 'mid_130': 32, 'mid_131': 32, 'mid_132': 32, 'mid_133': 32, 'mid_134': 32, 'mid_135': 32,
-                         'mid_136': 32, 'mid_137': 32, 'mid_138': 32, 'mid_139': 32, 'up_49': 32, 'up_51': 32, 'up_53': 32, 'up_55': 32, 'up_57': 32,
-                         'up_59': 32, 'up_61': 32, 'up_63': 32, 'up_65': 32, 'up_67': 32, 'up_69': 32, 'up_71': 32, 'up_73': 32, 'up_75': 32,
-                         'up_77': 32, 'up_79': 32, 'up_81': 32, 'up_83': 32, 'up_85': 32, 'up_87': 32, 'up_89': 32, 'up_91': 32, 'up_93': 32,
-                         'up_95': 32, 'up_97': 32, 'up_99': 32, 'up_101': 32, 'up_103': 32, 'up_105': 32, 'up_107': 32, 'up_109': 64, 'up_111': 64,
-                         'up_113': 64, 'up_115': 64, 'up_117': 64, 'up_119': 64}
+    _template_res = {'down_0': 64, 'down_1': 64, 'down_2': 64, 'down_3': 64, 'down_4': 64, 'down_5': 64, 'down_6': 64, 'down_7': 64,
+                     'down_8': 32, 'down_9': 32, 'down_10': 32, 'down_11': 32, 'down_12': 32, 'down_13': 32, 'down_14': 32, 'down_15': 32,
+                     'down_16': 32, 'down_17': 32, 'down_18': 32, 'down_19': 32, 'down_20': 32, 'down_21': 32, 'down_22': 32, 'down_23': 32,
+                     'down_24': 32, 'down_25': 32, 'down_26': 32, 'down_27': 32, 'down_28': 32, 'down_29': 32, 'down_30': 32, 'down_31': 32,
+                     'down_32': 32, 'down_33': 32, 'down_34': 32, 'down_35': 32, 'down_36': 32, 'down_37': 32, 'down_38': 32, 'down_39': 32,
+                     'down_40': 32, 'down_41': 32, 'down_42': 32, 'down_43': 32, 'down_44': 32, 'down_45': 32, 'down_46': 32, 'down_47': 32,
+                     'mid_120': 32, 'mid_121': 32, 'mid_122': 32, 'mid_123': 32, 'mid_124': 32, 'mid_125': 32, 'mid_126': 32, 'mid_127': 32,
+                     'mid_128': 32, 'mid_129': 32, 'mid_130': 32, 'mid_131': 32, 'mid_132': 32, 'mid_133': 32, 'mid_134': 32, 'mid_135': 32,
+                     'mid_136': 32, 'mid_137': 32, 'mid_138': 32, 'mid_139': 32, 'up_49': 32, 'up_51': 32, 'up_53': 32, 'up_55': 32, 'up_57': 32,
+                     'up_59': 32, 'up_61': 32, 'up_63': 32, 'up_65': 32, 'up_67': 32, 'up_69': 32, 'up_71': 32, 'up_73': 32, 'up_75': 32,
+                     'up_77': 32, 'up_79': 32, 'up_81': 32, 'up_83': 32, 'up_85': 32, 'up_87': 32, 'up_89': 32, 'up_91': 32, 'up_93': 32,
+                     'up_95': 32, 'up_97': 32, 'up_99': 32, 'up_101': 32, 'up_103': 32, 'up_105': 32, 'up_107': 32, 'up_109': 64, 'up_111': 64,
+                     'up_113': 64, 'up_115': 64, 'up_117': 64, 'up_119': 64}
+    high_res = attnstore.ALL_RES[1]
+    low_res = attnstore.ALL_RES[0]
+    DICT_PLACE_TO_RES = {k: (high_res if v == 64 else low_res) for k, v in _template_res.items()}
     attn_procs = {}
     for i, name in enumerate(unet.attn_processors.keys()):
         is_self_attn = (i % 2 == 0)

--- a/consistory_cache.py
+++ b/consistory_cache.py
@@ -50,14 +50,14 @@ def create_token_indices(prompts, batch_size, concept_token, tokenizer):
 
     return token_indices
 
-def create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type):
+def create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type, latent_size):
     # if seed is int
     if isinstance(seed, int):
         g = torch.Generator('cuda').manual_seed(seed)
-        shape = (batch_size, story_pipeline.unet.config.in_channels, 128, 128)
+        shape = (batch_size, story_pipeline.unet.config.in_channels, latent_size, latent_size)
         latents = randn_tensor(shape, generator=g, device=device, dtype=float_type)
     elif isinstance(seed, list):
-        shape = (batch_size, story_pipeline.unet.config.in_channels, 128, 128)
+        shape = (batch_size, story_pipeline.unet.config.in_channels, latent_size, latent_size)
         latents = torch.empty(shape, device=device, dtype=float_type)
         for i, seed_i in enumerate(seed):
             g = torch.Generator('cuda').manual_seed(seed_i)
@@ -73,8 +73,9 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
                    seed=40, n_steps=50, mask_dropout=0.5,
                    same_latent=False, share_queries=True,
                    perform_sdsa=True, perform_injection=True,
-                   downscale_rate=4):
-    latent_resolutions = [32, 64]
+                   downscale_rate=4, image_size=1024):
+    latent_size = image_size // story_pipeline.vae_scale_factor
+    latent_resolutions = [latent_size // 4, latent_size // 2]
 
     device = story_pipeline.device
     tokenizer = story_pipeline.tokenizer
@@ -87,13 +88,14 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
 
     default_attention_store_kwargs = {
         'token_indices': token_indices,
-        'mask_dropout': mask_dropout
+        'mask_dropout': mask_dropout,
+        'attn_res': (latent_size // 4, latent_size // 4)
     }
 
     default_extended_attn_kwargs = {'extend_kv_unet_parts': ['up']}
     query_store_kwargs={'t_range': [0,n_steps//10], 'strength_start': 0.9, 'strength_end': 0.81836735}
 
-    latents, g = create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type)
+    latents, g = create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type, latent_size)
 
     anchor_cache_first_stage = AnchorCache()
     anchor_cache_second_stage = AnchorCache()
@@ -107,12 +109,13 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
         extended_attn_kwargs = {**default_extended_attn_kwargs, 't_range': []}
 
     print(extended_attn_kwargs['t_range'])
-    out = story_pipeline(prompt=prompts, generator=g, latents=latents, 
+    out = story_pipeline(prompt=prompts, generator=g, latents=latents,
                         attention_store_kwargs=default_attention_store_kwargs,
                         extended_attn_kwargs=extended_attn_kwargs,
                         share_queries=share_queries,
                         query_store_kwargs=query_store_kwargs,
                         anchors_cache=anchor_cache_first_stage,
+                        height=image_size, width=image_size,
                         num_inference_steps=n_steps)
     last_masks = story_pipeline.attention_store.last_mask
 
@@ -131,16 +134,17 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
     # Extended attention with nn_map #
     
     if perform_injection:
-        feature_injector = FeatureInjector(nn_map, nn_distances, last_masks, inject_range_alpha=[(n_steps//10, n_steps//3,0.8)], 
-                                        swap_strategy='min', inject_unet_parts=['up', 'down'], dist_thr='dynamic')
+        feature_injector = FeatureInjector(nn_map, nn_distances, last_masks, inject_range_alpha=[(n_steps//10, n_steps//3,0.8)],
+                                        swap_strategy='min', inject_unet_parts=['up', 'down'], dist_thr='dynamic', latent_size=latent_size)
 
-        out = story_pipeline(prompt=prompts, generator=g, latents=latents, 
+        out = story_pipeline(prompt=prompts, generator=g, latents=latents,
                             attention_store_kwargs=default_attention_store_kwargs,
                             extended_attn_kwargs=extended_attn_kwargs,
                             share_queries=share_queries,
                             query_store_kwargs=query_store_kwargs,
                             feature_injector=feature_injector,
                             anchors_cache=anchor_cache_second_stage,
+                            height=image_size, width=image_size,
                             num_inference_steps=n_steps)
         img_all = view_images([np.array(x) for x in out.images], display_image=False, downscale_rate=downscale_rate)
         # display_attn_maps(story_pipeline.attention_store.last_mask, out.images)
@@ -155,13 +159,14 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
     
     return out.images, img_all, anchor_cache_first_stage, anchor_cache_second_stage
 
-def run_extra_generation(story_pipeline, prompts, concept_token, 
+def run_extra_generation(story_pipeline, prompts, concept_token,
                          anchor_cache_first_stage, anchor_cache_second_stage,
                          seed=40, n_steps=50, mask_dropout=0.5,
                          same_latent=False, share_queries=True,
                          perform_sdsa=True, perform_injection=True,
-                         downscale_rate=4):
-    latent_resolutions = [32, 64]
+                         downscale_rate=4, image_size=1024):
+    latent_size = image_size // story_pipeline.vae_scale_factor
+    latent_resolutions = [latent_size // 4, latent_size // 2]
 
     device = story_pipeline.device
     tokenizer = story_pipeline.tokenizer
@@ -174,7 +179,8 @@ def run_extra_generation(story_pipeline, prompts, concept_token,
 
     default_attention_store_kwargs = {
         'token_indices': token_indices,
-        'mask_dropout': mask_dropout
+        'mask_dropout': mask_dropout,
+        'attn_res': (latent_size // 4, latent_size // 4)
     }
 
     default_extended_attn_kwargs = {'extend_kv_unet_parts': ['up']}
@@ -184,7 +190,7 @@ def run_extra_generation(story_pipeline, prompts, concept_token,
     if isinstance(seed, list):
         seed = [seed[0], seed[0], *seed]
 
-    latents, g = create_latents(story_pipeline, seed, extra_batch_size, same_latent, device, float_type)
+    latents, g = create_latents(story_pipeline, seed, extra_batch_size, same_latent, device, float_type, latent_size)
     latents = latents[2:]
 
     anchor_cache_first_stage.set_mode_inject()
@@ -199,12 +205,13 @@ def run_extra_generation(story_pipeline, prompts, concept_token,
         extended_attn_kwargs = {**default_extended_attn_kwargs, 't_range': []}
 
     print(extended_attn_kwargs['t_range'])
-    out = story_pipeline(prompt=prompts, generator=g, latents=latents, 
+    out = story_pipeline(prompt=prompts, generator=g, latents=latents,
                         attention_store_kwargs=default_attention_store_kwargs,
                         extended_attn_kwargs=extended_attn_kwargs,
                         share_queries=share_queries,
                         query_store_kwargs=query_store_kwargs,
                         anchors_cache=anchor_cache_first_stage,
+                        height=image_size, width=image_size,
                         num_inference_steps=n_steps)
     last_masks = story_pipeline.attention_store.last_mask
 
@@ -223,16 +230,17 @@ def run_extra_generation(story_pipeline, prompts, concept_token,
     # Extended attention with nn_map #
     
     if perform_injection:
-        feature_injector = FeatureInjector(nn_map, nn_distances, last_masks, inject_range_alpha=[(n_steps//10, n_steps//3,0.8)], 
-                                        swap_strategy='min', inject_unet_parts=['up', 'down'], dist_thr='dynamic')
+        feature_injector = FeatureInjector(nn_map, nn_distances, last_masks, inject_range_alpha=[(n_steps//10, n_steps//3,0.8)],
+                                        swap_strategy='min', inject_unet_parts=['up', 'down'], dist_thr='dynamic', latent_size=latent_size)
 
-        out = story_pipeline(prompt=prompts, generator=g, latents=latents, 
+        out = story_pipeline(prompt=prompts, generator=g, latents=latents,
                             attention_store_kwargs=default_attention_store_kwargs,
                             extended_attn_kwargs=extended_attn_kwargs,
                             share_queries=share_queries,
                             query_store_kwargs=query_store_kwargs,
                             feature_injector=feature_injector,
                             anchors_cache=anchor_cache_second_stage,
+                            height=image_size, width=image_size,
                             num_inference_steps=n_steps)
         img_all = view_images([np.array(x) for x in out.images], display_image=False, downscale_rate=downscale_rate)
         # display_attn_maps(story_pipeline.attention_store.last_mask, out.images)

--- a/consistory_run.py
+++ b/consistory_run.py
@@ -13,7 +13,6 @@ import gc
 
 from utils.ptp_utils import view_images
 
-LATENT_RESOLUTIONS = [32, 64]
 
 def load_pipeline(gpu_id=0):
     float_type = torch.float16
@@ -51,14 +50,14 @@ def create_token_indices(prompts, batch_size, concept_token, tokenizer):
 
     return token_indices
 
-def create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type):
+def create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type, latent_size):
     # if seed is int
     if isinstance(seed, int):
         g = torch.Generator('cuda').manual_seed(seed)
-        shape = (batch_size, story_pipeline.unet.config.in_channels, 128, 128)
+        shape = (batch_size, story_pipeline.unet.config.in_channels, latent_size, latent_size)
         latents = randn_tensor(shape, generator=g, device=device, dtype=float_type)
     elif isinstance(seed, list):
-        shape = (batch_size, story_pipeline.unet.config.in_channels, 128, 128)
+        shape = (batch_size, story_pipeline.unet.config.in_channels, latent_size, latent_size)
         latents = torch.empty(shape, device=device, dtype=float_type)
         for i, seed_i in enumerate(seed):
             g = torch.Generator('cuda').manual_seed(seed_i)
@@ -75,13 +74,16 @@ def run_batch_generation(story_pipeline, prompts, concept_token,
                         seed=40, n_steps=50, mask_dropout=0.5,
                         same_latent=False, share_queries=True,
                         perform_sdsa=True, perform_injection=True,
-                        downscale_rate=4, n_achors=2):
+                        downscale_rate=4, n_achors=2,
+                        image_size=1024):
     device = story_pipeline.device
     tokenizer = story_pipeline.tokenizer
     float_type = story_pipeline.dtype
     unet = story_pipeline.unet
 
     batch_size = len(prompts)
+    latent_size = image_size // story_pipeline.vae_scale_factor
+    latent_resolutions = [latent_size // 4, latent_size // 2]
 
     token_indices = create_token_indices(prompts, batch_size, concept_token, tokenizer)
     anchor_mappings = create_anchor_mapping(batch_size, anchor_indices=list(range(n_achors)))
@@ -89,13 +91,14 @@ def run_batch_generation(story_pipeline, prompts, concept_token,
     default_attention_store_kwargs = {
         'token_indices': token_indices,
         'mask_dropout': mask_dropout,
-        'extended_mapping': anchor_mappings
+        'extended_mapping': anchor_mappings,
+        'attn_res': (latent_size // 4, latent_size // 4)
     }
 
     default_extended_attn_kwargs = {'extend_kv_unet_parts': ['up']}
     query_store_kwargs= {'t_range': [0,n_steps//10], 'strength_start': 0.9, 'strength_end': 0.81836735}
 
-    latents, g = create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type)
+    latents, g = create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type, latent_size)
 
     # ------------------ #
     # Extended attention First Run #
@@ -106,18 +109,19 @@ def run_batch_generation(story_pipeline, prompts, concept_token,
         extended_attn_kwargs = {**default_extended_attn_kwargs, 't_range': []}
 
     print(extended_attn_kwargs['t_range'])
-    out = story_pipeline(prompt=prompts, generator=g, latents=latents, 
+    out = story_pipeline(prompt=prompts, generator=g, latents=latents,
                         attention_store_kwargs=default_attention_store_kwargs,
                         extended_attn_kwargs=extended_attn_kwargs,
                         share_queries=share_queries,
                         query_store_kwargs=query_store_kwargs,
+                        height=image_size, width=image_size,
                         num_inference_steps=n_steps)
     last_masks = story_pipeline.attention_store.last_mask
 
     dift_features = unet.latent_store.dift_features['261_0'][batch_size:]
     dift_features = torch.stack([gaussian_smooth(x, kernel_size=3, sigma=1) for x in dift_features], dim=0)
 
-    nn_map, nn_distances = cyclic_nn_map(dift_features, last_masks, LATENT_RESOLUTIONS, device)
+    nn_map, nn_distances = cyclic_nn_map(dift_features, last_masks, latent_resolutions, device)
 
     torch.cuda.empty_cache()
     gc.collect()
@@ -126,15 +130,16 @@ def run_batch_generation(story_pipeline, prompts, concept_token,
     # Extended attention with nn_map #
     
     if perform_injection:
-        feature_injector = FeatureInjector(nn_map, nn_distances, last_masks, inject_range_alpha=[(n_steps//10, n_steps//3,0.8)], 
-                                        swap_strategy='min', inject_unet_parts=['up', 'down'], dist_thr='dynamic')
+        feature_injector = FeatureInjector(nn_map, nn_distances, last_masks, inject_range_alpha=[(n_steps//10, n_steps//3,0.8)],
+                                        swap_strategy='min', inject_unet_parts=['up', 'down'], dist_thr='dynamic', latent_size=latent_size)
 
-        out = story_pipeline(prompt=prompts, generator=g, latents=latents, 
+        out = story_pipeline(prompt=prompts, generator=g, latents=latents,
                             attention_store_kwargs=default_attention_store_kwargs,
                             extended_attn_kwargs=extended_attn_kwargs,
                             share_queries=share_queries,
                             query_store_kwargs=query_store_kwargs,
                             feature_injector=feature_injector,
+                            height=image_size, width=image_size,
                             num_inference_steps=n_steps)
         img_all = view_images([np.array(x) for x in out.images], display_image=False, downscale_rate=downscale_rate)
         # display_attn_maps(story_pipeline.attention_store.last_mask, out.images)
@@ -151,25 +156,29 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
                         seed=40, n_steps=50, mask_dropout=0.5,
                         same_latent=False, share_queries=True,
                         perform_sdsa=True, perform_injection=True,
-                        downscale_rate=4, cache_cpu_offloading=False):
+                        downscale_rate=4, cache_cpu_offloading=False,
+                        image_size=1024):
     device = story_pipeline.device
     tokenizer = story_pipeline.tokenizer
     float_type = story_pipeline.dtype
     unet = story_pipeline.unet
 
     batch_size = len(prompts)
+    latent_size = image_size // story_pipeline.vae_scale_factor
+    latent_resolutions = [latent_size // 4, latent_size // 2]
 
     token_indices = create_token_indices(prompts, batch_size, concept_token, tokenizer)
 
     default_attention_store_kwargs = {
         'token_indices': token_indices,
-        'mask_dropout': mask_dropout
+        'mask_dropout': mask_dropout,
+        'attn_res': (latent_size // 4, latent_size // 4)
     }
 
     default_extended_attn_kwargs = {'extend_kv_unet_parts': ['up']}
     query_store_kwargs={'t_range': [0,n_steps//10], 'strength_start': 0.9, 'strength_end': 0.81836735}
 
-    latents, g = create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type)
+    latents, g = create_latents(story_pipeline, seed, batch_size, same_latent, device, float_type, latent_size)
 
     anchor_cache_first_stage = AnchorCache()
     anchor_cache_second_stage = AnchorCache()
@@ -183,12 +192,13 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
         extended_attn_kwargs = {**default_extended_attn_kwargs, 't_range': []}
 
     print(extended_attn_kwargs['t_range'])
-    out = story_pipeline(prompt=prompts, generator=g, latents=latents, 
+    out = story_pipeline(prompt=prompts, generator=g, latents=latents,
                         attention_store_kwargs=default_attention_store_kwargs,
                         extended_attn_kwargs=extended_attn_kwargs,
                         share_queries=share_queries,
                         query_store_kwargs=query_store_kwargs,
                         anchors_cache=anchor_cache_first_stage,
+                        height=image_size, width=image_size,
                         num_inference_steps=n_steps)
     last_masks = story_pipeline.attention_store.last_mask
 
@@ -201,7 +211,7 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
     if cache_cpu_offloading:
         anchor_cache_first_stage.to_device(torch.device('cpu'))
 
-    nn_map, nn_distances = cyclic_nn_map(dift_features, last_masks, LATENT_RESOLUTIONS, device)
+    nn_map, nn_distances = cyclic_nn_map(dift_features, last_masks, latent_resolutions, device)
 
     torch.cuda.empty_cache()
     gc.collect()
@@ -210,16 +220,17 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
     # Extended attention with nn_map #
     
     if perform_injection:
-        feature_injector = FeatureInjector(nn_map, nn_distances, last_masks, inject_range_alpha=[(n_steps//10, n_steps//3,0.8)], 
-                                        swap_strategy='min', inject_unet_parts=['up', 'down'], dist_thr='dynamic')
+        feature_injector = FeatureInjector(nn_map, nn_distances, last_masks, inject_range_alpha=[(n_steps//10, n_steps//3,0.8)],
+                                        swap_strategy='min', inject_unet_parts=['up', 'down'], dist_thr='dynamic', latent_size=latent_size)
 
-        out = story_pipeline(prompt=prompts, generator=g, latents=latents, 
+        out = story_pipeline(prompt=prompts, generator=g, latents=latents,
                             attention_store_kwargs=default_attention_store_kwargs,
                             extended_attn_kwargs=extended_attn_kwargs,
                             share_queries=share_queries,
                             query_store_kwargs=query_store_kwargs,
                             feature_injector=feature_injector,
                             anchors_cache=anchor_cache_second_stage,
+                            height=image_size, width=image_size,
                             num_inference_steps=n_steps)
         img_all = view_images([np.array(x) for x in out.images], display_image=False, downscale_rate=downscale_rate)
         # display_attn_maps(story_pipeline.attention_store.last_mask, out.images)
@@ -237,24 +248,28 @@ def run_anchor_generation(story_pipeline, prompts, concept_token,
     
     return out.images, img_all, anchor_cache_first_stage, anchor_cache_second_stage
 
-def run_extra_generation(story_pipeline, prompts, concept_token, 
+def run_extra_generation(story_pipeline, prompts, concept_token,
                          anchor_cache_first_stage, anchor_cache_second_stage,
                          seed=40, n_steps=50, mask_dropout=0.5,
                          same_latent=False, share_queries=True,
                          perform_sdsa=True, perform_injection=True,
-                         downscale_rate=4, cache_cpu_offloading=False):
+                         downscale_rate=4, cache_cpu_offloading=False,
+                         image_size=1024):
     device = story_pipeline.device
     tokenizer = story_pipeline.tokenizer
     float_type = story_pipeline.dtype
     unet = story_pipeline.unet
 
     batch_size = len(prompts)
+    latent_size = image_size // story_pipeline.vae_scale_factor
+    latent_resolutions = [latent_size // 4, latent_size // 2]
 
     token_indices = create_token_indices(prompts, batch_size, concept_token, tokenizer)
 
     default_attention_store_kwargs = {
         'token_indices': token_indices,
-        'mask_dropout': mask_dropout
+        'mask_dropout': mask_dropout,
+        'attn_res': (latent_size // 4, latent_size // 4)
     }
 
     default_extended_attn_kwargs = {'extend_kv_unet_parts': ['up']}
@@ -264,7 +279,7 @@ def run_extra_generation(story_pipeline, prompts, concept_token,
     if isinstance(seed, list):
         seed = [seed[0], seed[0], *seed]
 
-    latents, g = create_latents(story_pipeline, seed, extra_batch_size, same_latent, device, float_type)
+    latents, g = create_latents(story_pipeline, seed, extra_batch_size, same_latent, device, float_type, latent_size)
     latents = latents[2:]
 
     anchor_cache_first_stage.set_mode_inject()
@@ -282,12 +297,13 @@ def run_extra_generation(story_pipeline, prompts, concept_token,
         extended_attn_kwargs = {**default_extended_attn_kwargs, 't_range': []}
 
     print(extended_attn_kwargs['t_range'])
-    out = story_pipeline(prompt=prompts, generator=g, latents=latents, 
+    out = story_pipeline(prompt=prompts, generator=g, latents=latents,
                         attention_store_kwargs=default_attention_store_kwargs,
                         extended_attn_kwargs=extended_attn_kwargs,
                         share_queries=share_queries,
                         query_store_kwargs=query_store_kwargs,
                         anchors_cache=anchor_cache_first_stage,
+                        height=image_size, width=image_size,
                         num_inference_steps=n_steps)
     last_masks = story_pipeline.attention_store.last_mask
 
@@ -297,7 +313,7 @@ def run_extra_generation(story_pipeline, prompts, concept_token,
     anchor_dift_features = anchor_cache_first_stage.dift_cache
     anchor_last_masks = anchor_cache_first_stage.anchors_last_mask
 
-    nn_map, nn_distances = anchor_nn_map(dift_features, anchor_dift_features, last_masks, anchor_last_masks, LATENT_RESOLUTIONS, device)
+    nn_map, nn_distances = anchor_nn_map(dift_features, anchor_dift_features, last_masks, anchor_last_masks, latent_resolutions, device)
 
     if cache_cpu_offloading:
         anchor_cache_first_stage.to_device(torch.device('cpu'))
@@ -313,16 +329,17 @@ def run_extra_generation(story_pipeline, prompts, concept_token,
         if cache_cpu_offloading:
             anchor_cache_second_stage.to_device(device)
 
-        feature_injector = FeatureInjector(nn_map, nn_distances, last_masks, inject_range_alpha=[(n_steps//10, n_steps//3,0.8)], 
-                                        swap_strategy='min', inject_unet_parts=['up', 'down'], dist_thr='dynamic')
+        feature_injector = FeatureInjector(nn_map, nn_distances, last_masks, inject_range_alpha=[(n_steps//10, n_steps//3,0.8)],
+                                        swap_strategy='min', inject_unet_parts=['up', 'down'], dist_thr='dynamic', latent_size=latent_size)
 
-        out = story_pipeline(prompt=prompts, generator=g, latents=latents, 
+        out = story_pipeline(prompt=prompts, generator=g, latents=latents,
                             attention_store_kwargs=default_attention_store_kwargs,
                             extended_attn_kwargs=extended_attn_kwargs,
                             share_queries=share_queries,
                             query_store_kwargs=query_store_kwargs,
                             feature_injector=feature_injector,
                             anchors_cache=anchor_cache_second_stage,
+                            height=image_size, width=image_size,
                             num_inference_steps=n_steps)
         img_all = view_images([np.array(x) for x in out.images], display_image=False, downscale_rate=downscale_rate)
         # display_attn_maps(story_pipeline.attention_store.last_mask, out.images)

--- a/consistory_utils.py
+++ b/consistory_utils.py
@@ -18,7 +18,7 @@ else:
     xformers = None
 
 class FeatureInjector:
-    def __init__(self, nn_map, nn_distances, attn_masks, inject_range_alpha=[(10,20,0.8)], swap_strategy='min', dist_thr='dynamic', inject_unet_parts=['up']):
+    def __init__(self, nn_map, nn_distances, attn_masks, inject_range_alpha=[(10,20,0.8)], swap_strategy='min', dist_thr='dynamic', inject_unet_parts=['up'], latent_size=128):
         self.nn_map = nn_map
         self.nn_distances = nn_distances
         self.attn_masks = attn_masks
@@ -27,7 +27,7 @@ class FeatureInjector:
         self.swap_strategy = swap_strategy # 'min / 'mean' / 'first'
         self.dist_thr = dist_thr
         self.inject_unet_parts = inject_unet_parts
-        self.inject_res = [64]
+        self.inject_res = [latent_size // 2]
 
     def inject_outputs(self, output, curr_iter, output_res, extended_mapping, place_in_unet, anchors_cache=None):
         curr_unet_part = place_in_unet.split('_')[0]

--- a/utils/ptp_utils.py
+++ b/utils/ptp_utils.py
@@ -116,7 +116,8 @@ class AttentionStore:
         torch.manual_seed(0) # For dropout mask reproducibility
 
         self.curr_iter = 0
-        self.ALL_RES = [32, 64]
+        base = self.attn_res[0]
+        self.ALL_RES = [base, base * 2]
         self.step_store = defaultdict(list)
         self.attn_masks = {res: None for res in self.ALL_RES}
         self.last_mask = {res: None for res in self.ALL_RES}


### PR DESCRIPTION
## Summary
- add `image_size` argument to generation utilities
- create latents dynamically and compute feature resolutions
- propagate height/width to pipeline calls
- scale attention store resolution and feature injection
- compute attention processor resolutions from current latent size

## Testing
- `python -m py_compile consistory_run.py consistory_cache.py consistory_pipeline.py attention_processor.py consistory_utils.py utils/general_utils.py utils/ptp_utils.py consistory_CLI.py consistory_unet_sdxl.py`

------
https://chatgpt.com/codex/tasks/task_b_6887279d53508331a1f018d3b27de69c